### PR TITLE
Mts columns

### DIFF
--- a/packages/eds-core/src/blocks/columns/columns.mts
+++ b/packages/eds-core/src/blocks/columns/columns.mts
@@ -1,5 +1,8 @@
 export default function decorate(block: Element) {
-  const cols: HTMLCollection = block.firstElementChild!.children;
+  const cols: HTMLCollection | undefined = block.firstElementChild?.children;
+  if (!cols) {
+    return
+  }
   block.classList.add(`columns-${cols.length}-cols`);
 
   // setup image columns

--- a/packages/eds-core/src/blocks/columns/columns.mts
+++ b/packages/eds-core/src/blocks/columns/columns.mts
@@ -1,10 +1,12 @@
-export default function decorate(block) {
-  const cols = [...block.firstElementChild.children];
+export default function decorate(block: Element) {
+  const cols: HTMLCollection = block.firstElementChild!.children;
   block.classList.add(`columns-${cols.length}-cols`);
 
   // setup image columns
-  [...block.children].forEach((row) => {
-    [...row.children].forEach((col) => {
+  const blockChildren: Array<Element> = Array.from(block.children)
+  blockChildren.forEach((row) => {
+    const rowChildren: Array<Element> = Array.from(row.children)
+    rowChildren.forEach((col) => {
       const pic = col.querySelector('picture');
       if (pic) {
         const picWrapper = pic.closest('div');


### PR DESCRIPTION
Switched columns.mjs to columns.mts

Currently if block.firstElementChild is undefined  it returns out of the function with no further logging or error handling. I was unsure of the appropriate way to handle this so I opted to keep it simple.