### PR TITLE
Prevent duplicate icons when decorating

### DIFF
--- a/packages/eds-core/package.json
+++ b/packages/eds-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shiftparadigm/eds-core",
-	"version": "0.1.0-alpha.8",
+	"version": "0.1.0-alpha.9",
 	"description": "",
 	"exports": {
 		"./*.css": {

--- a/packages/eds-core/src/utils/decorateIcon.mjs
+++ b/packages/eds-core/src/utils/decorateIcon.mjs
@@ -8,6 +8,12 @@ export function decorateIcon(span, prefix = '', alt = '') {
 	const iconName = Array.from(span.classList)
 		.find((c) => c.startsWith('icon-'))
 		.substring(5);
+
+	const existingIcon = [...span.querySelectorAll('img')].find((img) => {
+		return img.dataset.iconName === iconName;
+	});
+	if (existingIcon) return;
+
 	const img = document.createElement('img');
 	img.dataset.iconName = iconName;
 	img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;


### PR DESCRIPTION
If `decorateIcons` gets called twice, prevent it from creating duplicate icons like this:
![Screenshot 2024-08-06 081226](https://github.com/user-attachments/assets/44accfe8-89bf-450d-8621-b14ead59ec33)
