### PR TITLE
Add sourcemap build file

### DIFF
--- a/packages/eds-dev-tools/package.json
+++ b/packages/eds-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shiftparadigm/eds-dev-tools",
-	"version": "0.1.0-alpha.11",
+	"version": "0.1.0-alpha.12",
 	"description": "",
 	"bin": {
 		"shift-aem": "dist/dev.mjs",

--- a/packages/eds-dev-tools/src/build-sourcemap.mts
+++ b/packages/eds-dev-tools/src/build-sourcemap.mts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import { build } from 'vite';
+import { defaultViteConfigPathIfMissing } from './vite/config-resolver.mjs';
+
+await build({
+	configFile: defaultViteConfigPathIfMissing(),
+	build: {
+		watch: null,
+		sourcemap: true,
+	},
+});


### PR DESCRIPTION
This will allow us to turn on sourcemaps so Adobe can inspect our application.